### PR TITLE
Log watched file relative to cwd, rather than absolute path.

### DIFF
--- a/lib/pliers.js
+++ b/lib/pliers.js
@@ -2,6 +2,7 @@ var _ = require('lodash')
   , async = require('async')
   , fs = require('fs')
   , join = require('path').join
+  , relative = require('path').relative
   , pexec = require('child_process').exec
   , glob = require('glob')
   , noop = function () {}
@@ -230,7 +231,7 @@ module.exports = function pliers(options) {
   function watch(files, fn) {
 
     function watchFile(file) {
-      options.logger.debug('Watching ' + file)
+      options.logger.debug('Watching ' + relative(options.cwd, file))
       var fsWatcher = fs.watch(file, function (event) {
         options.logger.info('Changed ' + file, event)
         if (event !== 'rename') {


### PR DESCRIPTION
Just makes logs shorter and easier to consume:

Absolute:

```
2013-01-22T16:34:19.467Z Watching /Users/bengourley/Projects/DCPressAndJournal/source/templates/components/pages/search-page/search-page-sidebar.jade
```

Relative:

```
2013-01-22T16:45:21.051Z Watching source/templates/components/pages/search-page/search-page-sidebar.jade
```
