### PR TITLE
pliers.exec child process inherits parent's stdio (fixes #10)

### DIFF
--- a/lib/pliers.js
+++ b/lib/pliers.js
@@ -239,7 +239,11 @@ module.exports = function pliers(options) {
     options.logger.info('Executing ' + command)
     var args = command.trim().split(/ +/)
       , cmd = args.shift()
-    var child = spawn(cmd, args, { cwd: options.cwd, stdio: 'inherit' })
+
+    var child = spawn(cmd, args,
+      { cwd: options.cwd
+      , stdio: [ options.input, options.output, options.error ]
+      })
 
     child.on('exit', function () {
       cb()

--- a/test/fixtures/exec.js
+++ b/test/fixtures/exec.js
@@ -1,7 +1,4 @@
-
 function noop() {}
-var Stream = require('stream')
-  , nullStream = new Stream()
 
 var pliers = require('../..')(
   { logger:
@@ -9,7 +6,6 @@ var pliers = require('../..')(
     , info: noop
     , warn: noop
     , error: noop }
-  , output: nullStream
   })
 
 pliers.exec('node -v', function () {})

--- a/test/pliers.test.js
+++ b/test/pliers.test.js
@@ -11,7 +11,7 @@ nullStream.end = noop
 
 describe('pliers.js', function () {
 
-  function getPliers() {
+  function getPliers(outputStream) {
 
     return require('..')(
       { logger:
@@ -19,7 +19,7 @@ describe('pliers.js', function () {
         , info: noop
         , warn: noop
         , error: noop }
-      , output: nullStream
+      , output: outputStream ? undefined : nullStream
       })
   }
 
@@ -232,7 +232,7 @@ describe('pliers.js', function () {
 
   describe('exec()', function () {
 
-    var pliers = getPliers()
+    var pliers = getPliers(true)
 
     it('should throw if no command provided', function () {
       (function () {


### PR DESCRIPTION
It seems like the only way to convince the child process that it is in a TTY is to get it to inherit the parent process' stdio. You can't do this with `child_process.exec` ([whether it is a bug or not](https://github.com/joyent/node/issues/4691)) so I have switched to using `spawn`.

The caveat of this is I can't figure out how to also buffer only the output from the child process in order to pass it to the `pliers.exec` callback. I have commented that test out, so probably don't merge this if that's a desired feature.
