### PR TITLE
CLI: Replace path.join with path.resolve

### DIFF
--- a/pliers-cli.js
+++ b/pliers-cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var program = require('commander')
-  , join = require('path').join
+  , path = require('path')
   , tasks
   , pliers = require('./lib/pliers')
 
@@ -27,7 +27,7 @@ if (!program.tasks) {
 pliers = pliers({ logLevel: program.logLevel })
 
 try {
-  tasks = require(join(process.cwd(), program.tasks))
+  tasks = require(path.resolve(program.tasks))
 } catch (e) {
 
   // Detect if the error caught is the task file


### PR DESCRIPTION
This fixes an issue where absolute paths couldn't be used with the -t option.

`path.resolve` is a lot cleverer than `path.join` (which is rather naive). For example:

``` js
path.join('foo', '/bar')    // -> 'foo/bar'
path.resolve('foo', '/bar') // -> '/bar'
```

`path.resolve` also defaults to using the current working directory if no `from` argument is supplied, so we can leave that out.
