### PR TITLE
Allowing to specify pliers options from within a pliers.js task file

### DIFF
--- a/pliers-cli.js
+++ b/pliers-cli.js
@@ -24,8 +24,6 @@ if (!program.tasks) {
   program.tasks = 'pliers.js'
 }
 
-pliers = pliers({ logLevel: program.logLevel })
-
 try {
   tasks = require(path.resolve(program.tasks))
 } catch (e) {
@@ -43,6 +41,10 @@ try {
   }
 
 }
+
+tasks.options = tasks.options || { logLevel: program.logLevel }
+
+pliers = pliers(tasks.options)
 
 tasks(pliers)
 


### PR DESCRIPTION
An example would be to override the exec's child processes stdio.

```
tasks.options = { logLevel: 'info', output: bunyan.stdin }

bunyan.stdout.pipe(process.stdin)
```
